### PR TITLE
Add a TLS example using cert-manager

### DIFF
--- a/kubernetes-ingress/README.md
+++ b/kubernetes-ingress/README.md
@@ -4,8 +4,9 @@ Cilium uses the standard Kubernetes Ingress resource definition, with an `ingres
 
 *Note: that the ingress controller creates a service of LoadBalancer type, so [your environment will need to support this](https://github.com/cilium/cilium-service-mesh-beta/issues/3).*
 
-Examples: 
+Examples:
+
 * [HTTP](http.md)
 * [gRPC](grpc.md)
 * [TLS Termination](tls.md)
-* [TLS Termination using cert-manager](tls-with-cert-manager)
+* [TLS Termination using cert-manager](tls-with-cert-manager.md)

--- a/kubernetes-ingress/README.md
+++ b/kubernetes-ingress/README.md
@@ -8,7 +8,4 @@ Examples:
 * [HTTP](http.md)
 * [gRPC](grpc.md)
 * [TLS Termination](tls.md)
-
-
-
-
+* [TLS Termination using cert-manager](tls-with-cert-manager)

--- a/kubernetes-ingress/ca-issuer.yaml
+++ b/kubernetes-ingress/ca-issuer.yaml
@@ -13,6 +13,9 @@ metadata:
   namespace: default
 spec:
   isCA: true
+  privateKey:
+    algorithm: ECDSA
+    size: 256
   secretName: ca
   commonName: ca
   issuerRef:

--- a/kubernetes-ingress/ca-issuer.yaml
+++ b/kubernetes-ingress/ca-issuer.yaml
@@ -1,0 +1,29 @@
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: self-signed
+  namespace: default
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: ca
+  namespace: default
+spec:
+  isCA: true
+  secretName: ca
+  commonName: ca
+  issuerRef:
+    name: self-signed
+    kind: Issuer
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: ca-issuer
+  namespace: default
+spec:
+  ca:
+    secretName: ca

--- a/kubernetes-ingress/tls-with-cert-manager.md
+++ b/kubernetes-ingress/tls-with-cert-manager.md
@@ -24,21 +24,10 @@ kubectl apply -f https://raw.githubusercontent.com/cilium/cilium-service-mesh-be
 
 ## Deploy the ingress
 
-If you previously ran the HTTP and/or gRPC ingress demos, delete the ingresses:
+Follow the instructions from the [TLS demo](TLS.md) to deploy the ingress.
 
-```sh
-kubectl delete ingress basic-ingress grpc-ingress
-```
-
-The ingress configuration for this demo provides the same routing as those demos
-but with the addition of TLS termination. Deploy this ingress:
-
-```sh
-kubectl apply -f https://raw.githubusercontent.com/cilium/cilium-service-mesh-beta/main/kubernetes-ingress/tls-ingress.yaml
-```
-
-This creates a LoadBalancer service, which after around 30 seconds or so should
-be populated with an external IP address.
+These instructions will get you to install a LoadBalancer service, which after
+around 30 seconds or so should be populated with an external IP address.
 
 ```console
 $ kubectl get ingress
@@ -65,33 +54,20 @@ NAME               TYPE                DATA   AGE
 secret/demo-cert   kubernetes.io/tls   3      33m
 ```
 
+_Note: if you previously followed the the basic [TLS example](TLS.md) there was a pre-existing secret called `demo-cert`. This will be properly "updated" by cert-manager but the updated secret won't be picked up by Cilium ([#22](https://github.com/cilium/cilium-service-mesh-beta/issues/22)). You can work around this by deleting and re-creating the service `cilium-ingress-tls-ingress` after checking that cert-manager has properly created the secret. One way to do this is to delete and re-create the ingress config file tls-ingress.yaml_
+
 ## Edit /etc/hosts
 
-In this ingress configuration, the host names `hipstershop.cilium.rocks` and
-`bookinfo.cilium.rocks` are specified in the path routing rules. The client
-needs to specify which host it wants to access. This can be achieved by
-editing your local `/etc/hosts` file. (You will almost certainly need to be
-superuser to edit this file.) Add entries using the IP address
-assigned to the ingress service, so your file looks something like this:
-
-```text
-##
-# Host Database
-#
-# localhost is used to configure the loopback interface
-# when the system is booting.  Do not change this entry.
-##
-127.0.0.1       localhost
-255.255.255.255 broadcasthost
-...
-34.79.55.0 bookinfo.cilium.rocks
-34.79.55.0 hipstershop.cilium.rocks
-```
+Follow the same instructions as in the basic [TLS demo](TLS.md) to edit your
+`/etc/hosts` file with the IP address assigned to the ingress.
 
 ## Make requests
 
 By specifying the CA's certificate on a curl request, you can say that you trust
 certificates signed by that CA.
+
+This is very similar to the basic TLS demo, except that the CA's secret needs to
+be retrieved from the Kubernetes secret where it's stored.
 
 ```sh
 curl --cacert <(kubectl get secret ca -o="jsonpath={.data.ca\.crt}" | base64 -d) \

--- a/kubernetes-ingress/tls-with-cert-manager.md
+++ b/kubernetes-ingress/tls-with-cert-manager.md
@@ -1,0 +1,117 @@
+# Ingress example with TLS termination using cert-manager
+
+This example builds on the [HTTP](http.md) and [gRPC](grpc.md) ingress examples, adding TLS
+termination.
+
+## Create TLS certificate and private key
+
+We will be using cert-manager to obtain TLS certificates. Let us install
+cert-manager:
+
+```sh
+helm repo add jetstack https://charts.jetstack.io
+helm install cert-manager jetstack/cert-manager --version v1.7.1 --namespace cert-manager --set installCRDs=true --create-namespace
+```
+
+Now, create a CA Issuer:
+
+```sh
+kubectl apply -f https://raw.githubusercontent.com/cilium/cilium-service-mesh-beta/main/kubernetes-ingress/ca-issuer.yaml
+```
+
+## Deploy the ingress
+
+If you previously ran the HTTP and/or gRPC ingress demos, delete the ingresses:
+
+```sh
+kubectl delete ingress basic-ingress grpc-ingress
+```
+
+The ingress configuration for this demo provides the same routing as those demos
+but with the addition of TLS termination. Deploy this ingress:
+
+```sh
+kubectl apply -f https://raw.githubusercontent.com/cilium/cilium-service-mesh-beta/main/kubernetes-ingress/tls-ingress.yaml
+```
+
+This creates a LoadBalancer service, which after around 30 seconds or so should
+be populated with an external IP address.
+
+```sh
+❯ kubectl get ingress
+NAME          CLASS    HOSTS                                            ADDRESS        PORTS     AGE
+tls-ingress   cilium   hipstershop.cilium.rocks,bookinfo.cilium.rocks   35.195.24.75   80, 443   6m5s
+```
+
+To tell cert-manager that this Ingress needs a certificate, annotate the
+Ingress with the name of the CA issuer we previously created:
+
+```sh
+kubectl annotate ingress tls-ingress cert-manager.io/issuer=ca-issuer
+```
+
+This creates a Certificate object along with a Secret containing the TLS
+certificate.
+
+```sh
+$ kubectl get certificate,secret demo-cert
+NAME                                    READY   SECRET      AGE
+certificate.cert-manager.io/demo-cert   True    demo-cert   33m
+
+NAME               TYPE                DATA   AGE
+secret/demo-cert   kubernetes.io/tls   3      33m
+```
+
+## Edit /etc/hosts
+
+In this ingress configuration, the host names `hipstershop.cilium.rocks` and
+`bookinfo.cilium.rocks` are specified in the path routing rules. The client
+needs to specify which host it wants to access. This can be achieved by
+editing your local `/etc/hosts` file. (You will almost certainly need to be
+superuser to edit this file.) Add entries using the IP address
+assigned to the ingress service, so your file looks something like this:
+
+```sh
+##
+# Host Database
+#
+# localhost is used to configure the loopback interface
+# when the system is booting.  Do not change this entry.
+##
+127.0.0.1       localhost
+255.255.255.255 broadcasthost
+...
+34.79.55.0 bookinfo.cilium.rocks
+34.79.55.0 hipstershop.cilium.rocks
+```
+
+## Make requests
+
+By specifying the CA's certificate on a curl request, you can say that you trust certificates
+signed by that CA.
+
+```sh
+curl --cacert <(kubectl get secret ca -o="jsonpath={.data.ca\.crt}" | base64 -d) \
+    -v https://bookinfo.cilium.rocks/details/1
+```
+
+If you prefer, instead of supplying the CA you can specify `-k` to tell the curl client not to validate the
+server's certificate. Without either, you will get an error that the certificate
+was signed by an unknown authority.
+
+Specifying -v on the curl request, you can see that the TLS handshake took place successfully.
+
+Similarly you can specify the CA on a gRPC request like this:
+
+```sh
+grpcurl -proto ./demo.proto -cacert <(kubectl get secret ca -o="jsonpath={.data.ca\.crt}" | base64 -d) \
+    hipstershop.cilium.rocks:443 hipstershop.ProductCatalogService/ListProducts
+```
+
+(See the [gRPC](grpc.md) example if you don't already have the `demo.proto` file downloaded.)
+
+You can also visit https://bookinfo.cilium.rocks in your browser. The browser
+will warn you that the certificate authority is unknown but if you proceed past
+this, you should see the bookstore application home page.
+
+Note that requests will time out if you don't specify `https://`.

--- a/kubernetes-ingress/tls-with-cert-manager.md
+++ b/kubernetes-ingress/tls-with-cert-manager.md
@@ -1,12 +1,15 @@
 # Ingress example with TLS termination using cert-manager
 
-This example builds on the [HTTP](http.md) and [gRPC](grpc.md) ingress examples, adding TLS
-termination.
+This example builds on the [HTTP](http.md) and [gRPC](grpc.md) ingress
+examples, adding TLS termination. This example is similar to the
+[TLS](tls.md) ingress example, in which you had to manually create a
+self-signed CA using `minica`. In this example, you will be using
+[cert-manager](https://cert-manager.io/), a Kubernetes-native operator that
+issues and renews TLS certificates for you.
 
 ## Create TLS certificate and private key
 
-We will be using cert-manager to obtain TLS certificates. Let us install
-cert-manager:
+Let us install cert-manager:
 
 ```sh
 helm repo add jetstack https://charts.jetstack.io

--- a/kubernetes-ingress/tls-with-cert-manager.md
+++ b/kubernetes-ingress/tls-with-cert-manager.md
@@ -40,8 +40,8 @@ kubectl apply -f https://raw.githubusercontent.com/cilium/cilium-service-mesh-be
 This creates a LoadBalancer service, which after around 30 seconds or so should
 be populated with an external IP address.
 
-```sh
-❯ kubectl get ingress
+```console
+$ kubectl get ingress
 NAME          CLASS    HOSTS                                            ADDRESS        PORTS     AGE
 tls-ingress   cilium   hipstershop.cilium.rocks,bookinfo.cilium.rocks   35.195.24.75   80, 443   6m5s
 ```
@@ -56,7 +56,7 @@ kubectl annotate ingress tls-ingress cert-manager.io/issuer=ca-issuer
 This creates a Certificate object along with a Secret containing the TLS
 certificate.
 
-```sh
+```console
 $ kubectl get certificate,secret demo-cert
 NAME                                    READY   SECRET      AGE
 certificate.cert-manager.io/demo-cert   True    demo-cert   33m
@@ -74,7 +74,7 @@ editing your local `/etc/hosts` file. (You will almost certainly need to be
 superuser to edit this file.) Add entries using the IP address
 assigned to the ingress service, so your file looks something like this:
 
-```sh
+```text
 ##
 # Host Database
 #
@@ -90,19 +90,20 @@ assigned to the ingress service, so your file looks something like this:
 
 ## Make requests
 
-By specifying the CA's certificate on a curl request, you can say that you trust certificates
-signed by that CA.
+By specifying the CA's certificate on a curl request, you can say that you trust
+certificates signed by that CA.
 
 ```sh
 curl --cacert <(kubectl get secret ca -o="jsonpath={.data.ca\.crt}" | base64 -d) \
     -v https://bookinfo.cilium.rocks/details/1
 ```
 
-If you prefer, instead of supplying the CA you can specify `-k` to tell the curl client not to validate the
-server's certificate. Without either, you will get an error that the certificate
-was signed by an unknown authority.
+If you prefer, instead of supplying the CA you can specify `-k` to tell the curl
+client not to validate the server's certificate. Without either, you will get an
+error that the certificate was signed by an unknown authority.
 
-Specifying -v on the curl request, you can see that the TLS handshake took place successfully.
+Specifying `-v` on the curl request, you can see that the TLS handshake took
+place successfully.
 
 Similarly you can specify the CA on a gRPC request like this:
 
@@ -113,7 +114,7 @@ grpcurl -proto ./demo.proto -cacert <(kubectl get secret ca -o="jsonpath={.data.
 
 (See the [gRPC](grpc.md) example if you don't already have the `demo.proto` file downloaded.)
 
-You can also visit https://bookinfo.cilium.rocks in your browser. The browser
+You can also visit <https://bookinfo.cilium.rocks> in your browser. The browser
 will warn you that the certificate authority is unknown but if you proceed past
 this, you should see the bookstore application home page.
 

--- a/kubernetes-ingress/tls.md
+++ b/kubernetes-ingress/tls.md
@@ -1,18 +1,15 @@
 # Ingress example with TLS termination 
 
 This example builds on the [HTTP](http.md) and [gRPC](grpc.md) ingress examples, adding TLS
-termination.
+termination. 
 
 ## Create TLS certificate and private key
 
-For demonstration purposes we will use a TLS certificate signed by a
-made-up, self-signed certificate authority (CA). If you prefer using
-cert-manager to automate this part, you can read [Ingress example with TLS
-termination using cert-manager](./tls-with-cert-manager.md). One easy way to
-do this is with [`minica`](https://github.com/jsha/minica). We want a
-certificate that will validate bookinfo.cilium.rocks and
-hipstershop.cilium.rocks, as these are the host names used in this ingress
-example.
+For demonstration purposes we will use a TLS certificate signed by a made-up, [self-signed][]
+certificate authority (CA). One easy way to do this is with
+[`minica`](https://github.com/jsha/minica). We want a certificate that will
+validate bookinfo.cilium.rocks and hipstershop.cilium.rocks, as
+these are the host names used in this ingress example.
 
 ```
 minica -domains '*.cilium.rocks'

--- a/kubernetes-ingress/tls.md
+++ b/kubernetes-ingress/tls.md
@@ -1,15 +1,18 @@
 # Ingress example with TLS termination 
 
 This example builds on the [HTTP](http.md) and [gRPC](grpc.md) ingress examples, adding TLS
-termination. 
+termination.
 
 ## Create TLS certificate and private key
 
-For demonstration purposes we will use a TLS certificate signed by a made-up, self-signed 
-certificate authority (CA). One easy way to do this is with
-[`minica`](https://github.com/jsha/minica). We want a certificate that will
-validate bookinfo.cilium.rocks and hipstershop.cilium.rocks, as
-these are the host names used in this ingress example.
+For demonstration purposes we will use a TLS certificate signed by a
+made-up, self-signed certificate authority (CA). If you prefer using
+cert-manager to automate this part, you can read [Ingress example with TLS
+termination using cert-manager](./tls-with-cert-manager.md). One easy way to
+do this is with [`minica`](https://github.com/jsha/minica). We want a
+certificate that will validate bookinfo.cilium.rocks and
+hipstershop.cilium.rocks, as these are the host names used in this ingress
+example.
 
 ```
 minica -domains '*.cilium.rocks'

--- a/kubernetes-ingress/tls.md
+++ b/kubernetes-ingress/tls.md
@@ -11,6 +11,13 @@ certificate authority (CA). One easy way to do this is with
 validate bookinfo.cilium.rocks and hipstershop.cilium.rocks, as
 these are the host names used in this ingress example.
 
+> If you prefer using [cert-manager][] to automate this part, you may want
+> to follow this other example: [Ingress example with TLS termination using
+> cert-manager](./tls-with-cert-manager.md).
+
+[self-signed]: https://cert-manager.io/docs/faq/terminology/#what-does-self-signed-mean-is-my-ca-self-signed
+[cert-manager]: https://cert-manager.io/
+
 ```
 minica -domains '*.cilium.rocks'
 ```


### PR DESCRIPTION
I propose adding a new tutorial "TLS with cert-manager".

I tested the new tutorial using Kind and I documented the steps in the gist [Cilium ingress controller with cert-manager](https://gist.github.com/maelvls/ae61d43ee115585375029e628c0f4171) for anyone who wants to test this out locally.

xref: https://github.com/cert-manager/website/issues/851

cc @SgtCoDFish @irbekrm @wallrj @JoshVanL @jakexks